### PR TITLE
Add `/eth/syncing/l2` in dtl

### DIFF
--- a/packages/data-transport-layer/src/client/client.ts
+++ b/packages/data-transport-layer/src/client/client.ts
@@ -22,6 +22,10 @@ export class L1DataTransportClient {
     return this._get(`/eth/syncing`)
   }
 
+  public async syncingL2(): Promise<SyncingResponse> {
+    return this._get(`/eth/syncing/l2`)
+  }
+
   public async getEnqueueByIndex(index: number): Promise<EnqueueResponse> {
     return this._get(`/enqueue/index/${index}`)
   }

--- a/packages/data-transport-layer/src/db/transport-db.ts
+++ b/packages/data-transport-layer/src/db/transport-db.ts
@@ -25,6 +25,7 @@ const TRANSPORT_DB_KEYS = {
   STARTING_L1_BLOCK: `l1:starting`,
   HIGHEST_L2_BLOCK: `l2:highest`,
   HIGHEST_SYNCED_BLOCK: `synced:highest`,
+  TARGET_L2_BLOCK: `l2:target`,
 }
 
 interface Indexed {
@@ -213,6 +214,22 @@ export class TransportDB {
     return this.db.put<number>([
       {
         key: TRANSPORT_DB_KEYS.UNCONFIRMED_HIGHEST,
+        index: 0,
+        value: block,
+      },
+    ])
+  }
+
+  public async getTargetL2Block(): Promise<number> {
+    return (
+      (await this.db.get<number>(TRANSPORT_DB_KEYS.TARGET_L2_BLOCK, 0)) || 0
+    )
+  }
+
+  public async setTargetL2Block(block: number): Promise<void> {
+    return this.db.put<number>([
+      {
+        key: TRANSPORT_DB_KEYS.TARGET_L2_BLOCK,
         index: 0,
         value: block,
       },

--- a/packages/data-transport-layer/src/services/l2-ingestion/service.ts
+++ b/packages/data-transport-layer/src/services/l2-ingestion/service.ts
@@ -137,6 +137,7 @@ export class L2IngestionService extends BaseService<L2IngestionServiceOptions> {
         )
 
         await this.state.db.setHighestSyncedUnconfirmedBlock(targetL2Block)
+        await this.state.db.setTargetL2Block(currentL2Block)
 
         this.l2IngestionMetrics.highestSyncedL2Block.set(targetL2Block)
 


### PR DESCRIPTION
`/eth/syncing` returns the syncing status, but the design for this allows the replica to sync up before dtl loads all l2 data. Therefore, the `syncing` always returns `false` for l2geth.

This PR introduces the new api endpoint `/eth/syncing/l2`. This returns the actual syncing status, so we can query the actual `highest l2 block` that needs to be synced and current transaction index that dtl has synced. 
