### PR TITLE
Fix subgraphs for Fantom and Moonbase

### DIFF
--- a/packages/boba/subgraph/L1/rollup/src/L1CDMFastmapping.ts
+++ b/packages/boba/subgraph/L1/rollup/src/L1CDMFastmapping.ts
@@ -5,21 +5,23 @@ import {
 import { RelayedMessageFastEntity, FailedRelayedMessageFastEntity } from '../generated/schema'
 
 export function handleFailedRelayedMessage(event: FailedRelayedMessage): void {
-  const id = event.transaction.hash.toHex()
+  const id = event.params.msgHash.toHex()
   const entity = new FailedRelayedMessageFastEntity(id)
   entity.id = id
   entity.msgHash = event.params.msgHash
   entity.blockNumber = event.block.number
+  entity.transactionHash = event.transaction.hash
 
   entity.save()
 }
 
 export function handleRelayedMessage(event: RelayedMessage): void {
-  const id = event.transaction.hash.toHex()
+  const id = event.params.msgHash.toHex()
   const entity = new RelayedMessageFastEntity(id)
   entity.id = id
   entity.msgHash = event.params.msgHash
   entity.blockNumber = event.block.number
+  entity.transactionHash = event.transaction.hash
 
   entity.save()
 }

--- a/packages/boba/subgraph/L1/rollup/src/L1CDMmapping.ts
+++ b/packages/boba/subgraph/L1/rollup/src/L1CDMmapping.ts
@@ -5,7 +5,7 @@ import {
 import { RelayedMessageEntity, FailedRelayedMessageEntity } from "../generated/schema"
 
 export function handleFailedRelayedMessage(event: FailedRelayedMessage): void {
-  const id = event.transaction.hash.toHex()
+  const id = event.params.msgHash.toHex()
   const entity = new FailedRelayedMessageEntity(id)
   entity.id = id
   entity.msgHash = event.params.msgHash
@@ -16,7 +16,7 @@ export function handleFailedRelayedMessage(event: FailedRelayedMessage): void {
 }
 
 export function handleRelayedMessage(event: RelayedMessage): void {
-  const id = event.transaction.hash.toHex()
+  const id = event.params.msgHash.toHex()
   const entity = new RelayedMessageEntity(id)
   entity.id = id
   entity.msgHash = event.params.msgHash

--- a/packages/sdk/test/utils/graph.spec.ts
+++ b/packages/sdk/test/utils/graph.spec.ts
@@ -1,0 +1,78 @@
+import { expect } from 'chai'
+import { ethers } from 'ethers'
+import {
+  getRelayedMessageEventsFromGraph,
+  getAddressSetEventsFromGraph,
+  getStateBatchAppendedEventByBatchIndexFromGraph,
+} from '../../src'
+
+describe('subgraph tests', () => {
+  let provider: ethers.providers.Provider
+  before(async () => {
+    provider = new ethers.providers.JsonRpcProvider(
+      'https://rpc.testnet.fantom.network'
+    )
+  })
+
+  it('should get relayed message events', async () => {
+    // These two events are from the same block
+    const event_1 = await getRelayedMessageEventsFromGraph(
+      provider,
+      '0x1ab4456687fc99dbaf42fd88da031754fe13167fbca1922db2989e89151058e7',
+      false
+    )
+    expect(event_1).to.have.lengthOf(1)
+
+    const event_2 = await getRelayedMessageEventsFromGraph(
+      provider,
+      '0x75cdbb1106a93a5fefb47234c253da860f0114ed64a15f629c6fabb45170b222',
+      false
+    )
+    expect(event_1).to.have.lengthOf(1)
+    expect(event_2).to.have.lengthOf(1)
+    expect(event_1[0].transactionHash).to.equal(event_2[0].transactionHash)
+  })
+
+  it('should get transaction and transaction receipt from event', async () => {
+    const event = await getRelayedMessageEventsFromGraph(
+      provider,
+      '0x1ab4456687fc99dbaf42fd88da031754fe13167fbca1922db2989e89151058e7',
+      false
+    )
+    const transactionReceipt = await event[0].getTransactionReceipt()
+    expect(transactionReceipt).to.be.not.eq(null)
+
+    const transaction = await event[0].getTransaction()
+    expect(transaction).to.be.not.eq(null)
+  })
+
+  it('should get AddressSet events', async () => {
+    const event = await getAddressSetEventsFromGraph(
+      provider,
+      'Proxy__L2LiquidityPool',
+      9393760,
+      9393764
+    )
+    expect(event).to.have.lengthOf(1)
+
+    const transactionReceipt = await event[0].getTransactionReceipt()
+    expect(transactionReceipt).to.be.not.eq(null)
+
+    const transaction = await event[0].getTransaction()
+    expect(transaction).to.be.not.eq(null)
+  })
+
+  it('should get StateBatchAppended events', async () => {
+    const event = await getStateBatchAppendedEventByBatchIndexFromGraph(
+      provider,
+      13
+    )
+    expect(event).to.have.lengthOf(1)
+
+    const transactionReceipt = await event[0].getTransactionReceipt()
+    expect(transactionReceipt).to.be.not.eq(null)
+
+    const transaction = await event[0].getTransaction()
+    expect(transaction).to.be.not.eq(null)
+  })
+})


### PR DESCRIPTION
## Issue
The id of events can't be the transaction hash, because we might relay multiple L2 txs in one block so that subgraph only picks one event.

## Fix
The id of events is replaced by the unique msg hash.

## Tests

The unit tests are added.