### PR TITLE
Add more error messages to stablize integration tests

### DIFF
--- a/integration-tests/test/ovmcontext.spec.ts
+++ b/integration-tests/test/ovmcontext.spec.ts
@@ -144,7 +144,6 @@ describe('OVM Context: Layer 2 EVM Context', () => {
     // As atomically as possible, call `rollup_getInfo` and OVMMulticall for the
     // blocknumber and timestamp. If this is not atomic, then the sequencer can
     // happend to update the timestamp between the `eth_call` and the `rollup_getInfo`
-    await sleep(5000)
     const [info, [, returnData]] = await Promise.all([
       env.l2Provider.send('rollup_getInfo', []),
       OVMMulticall.callStatic.aggregate([

--- a/integration-tests/test/ovmcontext.spec.ts
+++ b/integration-tests/test/ovmcontext.spec.ts
@@ -1,6 +1,6 @@
 /* Imports: External */
 import { ethers } from 'hardhat'
-import { expectApprox } from '@eth-optimism/core-utils'
+import { expectApprox, sleep } from '@eth-optimism/core-utils'
 import { predeploys } from '@eth-optimism/contracts'
 import { Contract, BigNumber } from 'ethers'
 
@@ -144,6 +144,7 @@ describe('OVM Context: Layer 2 EVM Context', () => {
     // As atomically as possible, call `rollup_getInfo` and OVMMulticall for the
     // blocknumber and timestamp. If this is not atomic, then the sequencer can
     // happend to update the timestamp between the `eth_call` and the `rollup_getInfo`
+    await sleep(5000)
     const [info, [, returnData]] = await Promise.all([
       env.l2Provider.send('rollup_getInfo', []),
       OVMMulticall.callStatic.aggregate([

--- a/integration-tests/test/ovmcontext.spec.ts
+++ b/integration-tests/test/ovmcontext.spec.ts
@@ -1,6 +1,6 @@
 /* Imports: External */
 import { ethers } from 'hardhat'
-import { expectApprox, sleep } from '@eth-optimism/core-utils'
+import { expectApprox } from '@eth-optimism/core-utils'
 import { predeploys } from '@eth-optimism/contracts'
 import { Contract, BigNumber } from 'ethers'
 

--- a/integration-tests/test/shared/stress-test-helpers.ts
+++ b/integration-tests/test/shared/stress-test-helpers.ts
@@ -159,7 +159,8 @@ const retryOnNonceError = async (cb: () => Promise<any>): Promise<any> => {
         msg.includes('transaction was replaced') ||
         msg.includes('another transaction with same nonce in the queue') ||
         msg.includes('reverted without a reason') ||
-        msg.includes('replacement transaction underpriced')
+        msg.includes('replacement transaction underpriced') ||
+        msg.includes('Cannot commit transaction in miner')
       ) {
         console.warn('Retrying transaction after nonce error.')
         await sleep(5000)


### PR DESCRIPTION
## Problem
- I saw the `Cannot commit transaction in miner` error message in our stress tests occasionally. This requires us to re-run the tests and waste our time.

## How to solve
- Add `Cannot commit transaction in miner` error to resubmit the transaction